### PR TITLE
Change Zoom Control location

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -308,6 +308,7 @@
 
         var control = L.control.layers(baseLayers, null, {position: 'topleft'}).addTo(map);
 
+        var zoomControl = map.zoomControl.setPosition('bottomright');
 
         var sidebar = L.control.sidebar('sidebar').addTo(map);
 


### PR DESCRIPTION
Hey Efrem!
I find the location of the zoom button in the top left unnatural, as it's in the bottom right on Google Maps and Apple Maps. I did some searching and the setPosition method should change it. 

I've been going through your codebase a bit, could I submit a PR with some refactoring and unit tests? 

I will add more meaningful PRs soon,
Thanks! 
Eliot